### PR TITLE
Create 2.3. Swagger

### DIFF
--- a/2.3. Swagger
+++ b/2.3. Swagger
@@ -1,0 +1,42 @@
+package com.crud.tasks.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@EnableSwagger2
+@Configuration
+public class CoreConfiguration implements WebMvcConfigurer {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.crud.tasks.controller"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+    @Override
+    public void addResourceHandlers(final ResourceHandlerRegistry registry) {
+        //Required by Swagger UI configuration
+        registry.addResourceHandler("/lib/**").addResourceLocations("/lib/").setCachePeriod(0);
+        registry.addResourceHandler("/images/**").addResourceLocations("/images/").setCachePeriod(0);
+        registry.addResourceHandler("/css/**").addResourceLocations("/css/").setCachePeriod(0);
+        registry.addResourceHandler("/swagger-ui.html").addResourceLocations("classpath:/META-INF/resources/");
+        registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
+
+    }
+}


### PR DESCRIPTION
Zadanie: Ograniczenie skanowania w Swaggerze
Wykorzystaj zdobytą wiedzę o Swaggerze i dokumentację (skorzystaj z Google i https://swagger.io), aby ograniczyć skanowanie projektu tylko do pakietu com.crud.tasks.controller.